### PR TITLE
added half-pixel offsets to fix overlay/image alignment issues

### DIFF
--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -32,7 +32,7 @@ export class CursorOverlayComponent extends React.PureComponent<CursorOverlayPro
             infoStrings.push(`Canvas: (${cursorInfo.posCanvasSpace.x.toFixed(0)}, ${cursorInfo.posCanvasSpace.y.toFixed(0)})`);
         }
         if (this.props.showImage) {
-            infoStrings.push(`Image: (${cursorInfo.posImageSpace.x.toFixed(0)}, ${cursorInfo.posImageSpace.y.toFixed(0)})`);
+            infoStrings.push(`Image: (${cursorInfo.posImageSpace.x.toFixed(2)}, ${cursorInfo.posImageSpace.y.toFixed(2)})`);
         }
         if (this.props.showValue && this.props.cursorInfo.value !== undefined) {
             let valueString = `Value: ${this.expo(this.props.cursorInfo.value, 5, this.props.unit, true, true)}`;

--- a/src/components/ImageView/RasterView/RasterViewComponent.tsx
+++ b/src/components/ImageView/RasterView/RasterViewComponent.tsx
@@ -169,8 +169,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         const adjustedXMax = current.xMin + Math.floor((current.xMax - current.xMin) / current.mip) * current.mip;
         const adjustedYMax = current.yMin + Math.floor((current.yMax - current.yMin) / current.mip) * current.mip;
 
-        const LT = {x: (current.xMin - full.xMin) / fullWidth, y: (current.yMin - full.yMin) / fullHeight};
-        const RB = {x: (adjustedXMax - full.xMin) / fullWidth, y: (adjustedYMax - full.yMin) / fullHeight};
+        const LT = {x: (0.5 + current.xMin - full.xMin) / fullWidth, y: (0.5 + current.yMin - full.yMin) / fullHeight};
+        const RB = {x: (0.5 + adjustedXMax - full.xMin) / fullWidth, y: (0.5 + adjustedYMax - full.yMin) / fullHeight};
 
         // Vertices are mapped from [0-1] -> [-1, 1]
         const vertices = new Float32Array([
@@ -191,8 +191,8 @@ export class RasterViewComponent extends React.Component<RasterViewComponentProp
         if (frame.overviewRasterData) {
             const adjustedWidth = Math.floor(frame.frameInfo.fileInfoExtended.width / frame.overviewRasterView.mip) * frame.overviewRasterView.mip;
             const adjustedHeight = Math.floor(frame.frameInfo.fileInfoExtended.height / frame.overviewRasterView.mip) * frame.overviewRasterView.mip;
-            const overviewLT = {x: (0 - full.xMin) / fullWidth, y: (0 - full.yMin) / fullHeight};
-            const overviewRB = {x: (adjustedWidth - full.xMin) / fullWidth, y: (adjustedHeight - full.yMin) / fullHeight};
+            const overviewLT = {x: (0.5 - full.xMin) / fullWidth, y: (0.5 - full.yMin) / fullHeight};
+            const overviewRB = {x: (0.5 + adjustedWidth - full.xMin) / fullWidth, y: (0.5 + adjustedHeight - full.yMin) / fullHeight};
 
             const overviewVertices = new Float32Array([
                 overviewLT.x, overviewLT.y, 0.5,


### PR DESCRIPTION
Fixes #14. 
1) AST plot calls now use doubles in calculations
1) Images are now displayed with the middle of the pixel aligned with the coordinate of the pixel, similarly to DS9

![image](https://user-images.githubusercontent.com/592504/45498849-4fa6ec00-b77b-11e8-89fe-48e10b66a7ce.png)
