### PR TITLE
Add functionality test: FILETYPE_PARSER

### DIFF
--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -137,7 +137,6 @@ describe("FILETYPE_PARSER tests", () => {
             // While receive a message from Websocket server
             Connection.onmessage = (event: MessageEvent) => {
                 const eventData = new Uint8Array(event.data, 36);
-
                 expect(CARTA.FileListResponse.decode(eventData).parent).toBe(expectRootPath);
 
                 done();
@@ -163,14 +162,14 @@ describe("FILETYPE_PARSER tests", () => {
     
         }, connectTimeoutLocal);
 
-        describe(`assert the file is existed`, () => {
+        describe(`assert the file exists`, () => {
             [["S255_IR_sci.spw25.cube.I.pbcor.fits", CARTA.FileType.FITS, 7048405440],
              ["SDC335.579-0.292.spw0.line.image", CARTA.FileType.CASA, 1864975311],
              ["G34mm1.miriad", CARTA.FileType.MIRIAD, 7829305],
             ].map(
                 ([file, type, size]) => {
     
-                    test(`assert the file "${file}" is existed, image type is ${CARTA.FileType[type]}, size = ${size}.`, 
+                    test(`assert the file "${file}" exists, image type is ${CARTA.FileType[type]}, and size = ${size}.`, 
                     done => {
                         // While receive a message from Websocket server
                         Connection.onmessage = (event: MessageEvent) => {
@@ -193,12 +192,13 @@ describe("FILETYPE_PARSER tests", () => {
             )
         });
         
-        describe(`assert the file is not existed`, () => {
+        describe(`assert the file does not exist`, () => {
             [["empty2.miriad"], ["empty2.fits"], ["empty2.image"],
-            ["empty.txt"], ["empty.miriad"], ["empty.fits"], ["empty.image"],
+             ["empty.txt"], ["empty.miriad"], ["empty.fits"], 
+             ["empty.image"],
             ].map(
                 ([file]) => {
-                    test(`assert the file "${file}" is not existed.`, 
+                    test(`assert the file "${file}" does not exist.`, 
                     done => {
                         // While receive a message from Websocket server
                         Connection.onmessage = (event: MessageEvent) => {
@@ -219,11 +219,12 @@ describe("FILETYPE_PARSER tests", () => {
             )
         });        
         
-        describe(`assert the folder is existed in "FILE_LIST_RESPONSE.subdirectory"`, () => {
-            [["empty_folder"], ["empty2.miriad"], ["empty2.fits"], ["empty2.image"]
+        describe(`assert the folder exists in "FILE_LIST_RESPONSE.subdirectory"`, () => {
+            [["empty_folder"], ["empty2.miriad"], ["empty2.fits"], 
+             ["empty2.image"],
             ].map(
                 ([folder]) => {
-                    test(`assert the folder "${folder}" is existed.`, 
+                    test(`assert the folder "${folder}" exists.`, 
                     done => {
                         // While receive a message from Websocket server
                         Connection.onmessage = (event: MessageEvent) => {

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -3,8 +3,8 @@ import * as Utitlity from "./testUtilityFunction";
 
 let WebSocket = require('ws');
 let testServerUrl = "ws://localhost:50505";
-let testSubdirectoryName = "QA";
 let expectRootPath = "/home/user/CARTA/Images";
+let testSubdirectoryName = `${expectRootPath}/QA`;
 let connectTimeoutLocal = 300;
 
 describe("FILETYPE_PARSER tests", () => {   
@@ -72,13 +72,17 @@ describe("FILETYPE_PARSER tests", () => {
                 const eventData = new Uint8Array(event.data, 36);
                 expect(CARTA.FileListResponse.decode(eventData).success).toBe(true);
 
+                // console.log(CARTA.FileListResponse.decode(eventData));
+                console.log(`The root folder on backend is "${CARTA.FileListResponse.decode(eventData).parent}"`);
+                    
+
                 done();
             }
         }
 
     }, connectTimeoutLocal);
 
-    describe(`send EventName: "FILE_LIST_REQUEST" tests on CARTA ${testServerUrl}`, 
+    describe(`send EventName: "FILE_LIST_REQUEST" to CARTA ${testServerUrl}`, 
     () => {
         beforeEach( done => {
             // Preapare the message on a eventData
@@ -126,8 +130,7 @@ describe("FILETYPE_PARSER tests", () => {
                 const eventData = new Uint8Array(event.data, 36);
 
                 expect(CARTA.FileListResponse.decode(eventData).parent).toBe(expectRootPath);
-                console.log(CARTA.FileListResponse.decode(eventData).parent);
-                    
+
                 done();
             }
     
@@ -139,7 +142,6 @@ describe("FILETYPE_PARSER tests", () => {
             Connection.onmessage = (event: MessageEvent) => {
                 const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
                 if(eventName == "FILE_LIST_RESPONSE"){
-                    const eventId = new Uint32Array(event.data, 32, 1)[0];
                     const eventData = new Uint8Array(event.data, 36);
 
                     let parsedMessage;
@@ -163,7 +165,6 @@ describe("FILETYPE_PARSER tests", () => {
                         Connection.onmessage = (event: MessageEvent) => {
                             const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
                             if(eventName == "FILE_LIST_RESPONSE"){
-                                const eventId = new Uint32Array(event.data, 32, 1)[0];
                                 const eventData = new Uint8Array(event.data, 36);
     
                                 let parsedMessage;
@@ -179,24 +180,23 @@ describe("FILETYPE_PARSER tests", () => {
             )
         });        
         
-        describe(`assert the folder is not existed in "FILE_LIST_RESPONSE.subdirectory"`, () => {
+        describe(`assert the folder is existed in "FILE_LIST_RESPONSE.subdirectory"`, () => {
             [["empty_folder"], ["empty2.miriad"], ["empty2.fits"], ["empty2.image"], [".."]
             ].map(
                 ([folder]) => {
-                    test(`assert the folder "${folder}" is not existed.`, 
+                    test(`assert the folder "${folder}" is existed.`, 
                     done => {
                         // While receive a message from Websocket server
                         Connection.onmessage = (event: MessageEvent) => {
                             const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
                             if(eventName == "FILE_LIST_RESPONSE"){
-                                const eventId = new Uint32Array(event.data, 32, 1)[0];
                                 const eventData = new Uint8Array(event.data, 36);
     
                                 let parsedMessage;
                                 parsedMessage = CARTA.FileListResponse.decode(eventData);
     
-                                let folderInfo = parsedMessage.subdirectories.find(f => f.name === folder);
-                                expect(folderInfo).toBeUndefined();
+                                let folderInfo = parsedMessage.subdirectories.find(f => f === folder);
+                                expect(folderInfo).toBeDefined();
                             }
                             done();
                         } 
@@ -218,7 +218,6 @@ describe("FILETYPE_PARSER tests", () => {
                         Connection.onmessage = (event: MessageEvent) => {
                             const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
                             if(eventName == "FILE_LIST_RESPONSE"){
-                                const eventId = new Uint32Array(event.data, 32, 1)[0];
                                 const eventData = new Uint8Array(event.data, 36);
     
                                 let parsedMessage;

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -28,7 +28,7 @@ describe("FILETYPE_PARSER tests", () => {
 
                 Connection.send(eventData);
             } else {
-                console.log(`"FILE_LIST_REQUEST" can not open a connection.`);
+                console.log(`Can not open a connection.`);
             }
             done();
         };
@@ -61,7 +61,7 @@ describe("FILETYPE_PARSER tests", () => {
         };
     }, connectTimeoutLocal);
 
-    test(`send EventName: "FILE_LIST_REQUEST" to CARTA "${testServerUrl}" to access /${testSubdirectoryName}.`, 
+    test(`send EventName: "FILE_LIST_REQUEST" to CARTA "${testServerUrl}" to access ${testSubdirectoryName}.`, 
     done => {
         // While receive a message in the form of arraybuffer
         Connection.onmessage = (event: MessageEvent) => {
@@ -74,8 +74,7 @@ describe("FILETYPE_PARSER tests", () => {
 
             //    console.log(CARTA.FileListResponse.decode(eventData));
                 console.log(`The root folder on backend is "${CARTA.FileListResponse.decode(eventData).parent}"`);
-                    
-
+                
                 done();
             }
         }

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -1,0 +1,245 @@
+import {CARTA} from "carta-protobuf";
+import * as Utitlity from "./testUtilityFunction";
+
+let WebSocket = require('ws');
+let testServerUrl = "ws://localhost:50505";
+let testSubdirectoryName = "QA";
+let expectRootPath = "/home/user/CARTA/Images";
+let connectTimeoutLocal = 300;
+
+describe("FILETYPE_PARSER tests", () => {   
+    // Establish a websocket connection in the transfermation of binary: arraybuffer 
+    let Connection = new WebSocket(testServerUrl);
+    Connection.binaryType = "arraybuffer";
+
+    beforeAll( done => {
+        // While open a Websocket
+        Connection.onopen = () => {
+            // Checkout if Websocket server is ready
+            if (Connection.readyState == WebSocket.OPEN) {
+                // Preapare the message on a eventData
+                const message = CARTA.RegisterViewer.create({sessionId: "", apiKey: "1234"});
+                let payload = CARTA.RegisterViewer.encode(message).finish();
+                let eventData = new Uint8Array(32 + 4 + payload.byteLength);
+
+                eventData.set(Utitlity.stringToUint8Array("REGISTER_VIEWER", 32));
+                eventData.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                eventData.set(payload, 36);
+
+                Connection.send(eventData);
+            } else {
+                console.log(`"FILE_LIST_REQUEST" can not open a connection.`);
+            }
+            done();
+        };
+    }, connectTimeoutLocal);
+
+    test(`connect to CARTA "${testServerUrl}" & ...`, 
+    done => {
+        // While receive a message in the form of arraybuffer
+        Connection.onmessage = (event: MessageEvent) => {
+            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+            if(eventName == "REGISTER_VIEWER_ACK"){
+                // Assertion
+                expect(event.data.byteLength).toBeGreaterThan(0);
+                const eventData = new Uint8Array(event.data, 36);
+                expect(CARTA.RegisterViewerAck.decode(eventData).success).toBe(true);
+                
+                // Preapare the message on a eventData
+                const message = CARTA.FileListRequest.create({directory: testSubdirectoryName});
+                let payload = CARTA.FileListRequest.encode(message).finish();
+                const eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+    
+                eventDataTx.set(Utitlity.stringToUint8Array("FILE_LIST_REQUEST", 32));
+                eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                eventDataTx.set(payload, 36);
+    
+                Connection.send(eventDataTx);
+
+                done();
+            }
+        };
+    }, connectTimeoutLocal);
+
+    test(`send EventName: "FILE_LIST_REQUEST" to CARTA "${testServerUrl}" to access /${testSubdirectoryName}.`, 
+    done => {
+        // While receive a message in the form of arraybuffer
+        Connection.onmessage = (event: MessageEvent) => {
+            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+            
+            if(eventName == "FILE_LIST_RESPONSE"){
+                expect(event.data.byteLength).toBeGreaterThan(0);
+                const eventData = new Uint8Array(event.data, 36);
+                expect(CARTA.FileListResponse.decode(eventData).success).toBe(true);
+
+                done();
+            }
+        }
+
+    }, connectTimeoutLocal);
+
+    describe(`send EventName: "FILE_LIST_REQUEST" tests on CARTA ${testServerUrl}`, 
+    () => {
+        beforeEach( done => {
+            // Preapare the message on a eventData
+            const message = CARTA.FileListRequest.create({directory: testSubdirectoryName});
+            let payload = CARTA.FileListRequest.encode(message).finish();
+            const eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+
+            eventDataTx.set(Utitlity.stringToUint8Array("FILE_LIST_REQUEST", 32));
+            eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+            eventDataTx.set(payload, 36);
+
+            Connection.send(eventDataTx);
+
+            done();
+                       
+        }, connectTimeoutLocal);        
+        
+        test(`assert the received EventName is "FILE_LIST_RESPONSE" within ${connectTimeoutLocal * 1e-3} seconds.`, 
+        done => {
+            // While receive a message from Websocket server
+            Connection.onmessage = (event: MessageEvent) => {
+                const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                expect(event.data.byteLength).toBeGreaterThan(40);
+                expect(eventName).toBe("FILE_LIST_RESPONSE");
+
+                done();
+            }
+        }, connectTimeoutLocal);
+    
+        test(`assert the "FILE_LIST_RESPONSE.success" is true.`, 
+        done => {
+            // While receive a message from Websocket server
+            Connection.onmessage = (event: MessageEvent) => {
+                const eventData = new Uint8Array(event.data, 36);
+                expect(CARTA.FileListResponse.decode(eventData).success).toBe(true);
+                
+                done();
+            }
+        }, connectTimeoutLocal);  
+
+        test(`assert the "FILE_LIST_RESPONSE.parent" is "${expectRootPath}".`, 
+        done => {
+            // While receive a message from Websocket server
+            Connection.onmessage = (event: MessageEvent) => {
+                const eventData = new Uint8Array(event.data, 36);
+
+                expect(CARTA.FileListResponse.decode(eventData).parent).toBe(expectRootPath);
+                console.log(CARTA.FileListResponse.decode(eventData).parent);
+                    
+                done();
+            }
+    
+        }, connectTimeoutLocal);
+
+        test(`assert the "FILE_LIST_RESPONSE.directory" is the path "${testSubdirectoryName}".`, 
+        done => {
+            // While receive a message from Websocket server
+            Connection.onmessage = (event: MessageEvent) => {
+                const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                if(eventName == "FILE_LIST_RESPONSE"){
+                    const eventId = new Uint32Array(event.data, 32, 1)[0];
+                    const eventData = new Uint8Array(event.data, 36);
+
+                    let parsedMessage;
+                    parsedMessage = CARTA.FileListResponse.decode(eventData);
+
+                    expect(parsedMessage.directory).toBe(testSubdirectoryName);
+                }
+                done();
+            }
+    
+        }, connectTimeoutLocal);
+
+        describe(`assert the file is not existed`, () => {
+            [["empty2.miriad"], ["empty2.fits"], ["empty2.image"],
+            ["empty.txt"], ["empty.miriad"], ["empty.fits"], ["empty.image"],
+            ].map(
+                ([file]) => {
+                    test(`assert the file "${file}" is not existed.`, 
+                    done => {
+                        // While receive a message from Websocket server
+                        Connection.onmessage = (event: MessageEvent) => {
+                            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                            if(eventName == "FILE_LIST_RESPONSE"){
+                                const eventId = new Uint32Array(event.data, 32, 1)[0];
+                                const eventData = new Uint8Array(event.data, 36);
+    
+                                let parsedMessage;
+                                parsedMessage = CARTA.FileListResponse.decode(eventData);
+    
+                                let fileInfo = parsedMessage.files.find(f => f.name === file);
+                                expect(fileInfo).toBeUndefined();
+                            }
+                            done();
+                        } 
+                    }, connectTimeoutLocal)
+                }
+            )
+        });        
+        
+        describe(`assert the folder is not existed in "FILE_LIST_RESPONSE.subdirectory"`, () => {
+            [["empty_folder"], ["empty2.miriad"], ["empty2.fits"], ["empty2.image"], [".."]
+            ].map(
+                ([folder]) => {
+                    test(`assert the folder "${folder}" is not existed.`, 
+                    done => {
+                        // While receive a message from Websocket server
+                        Connection.onmessage = (event: MessageEvent) => {
+                            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                            if(eventName == "FILE_LIST_RESPONSE"){
+                                const eventId = new Uint32Array(event.data, 32, 1)[0];
+                                const eventData = new Uint8Array(event.data, 36);
+    
+                                let parsedMessage;
+                                parsedMessage = CARTA.FileListResponse.decode(eventData);
+    
+                                let folderInfo = parsedMessage.subdirectories.find(f => f.name === folder);
+                                expect(folderInfo).toBeUndefined();
+                            }
+                            done();
+                        } 
+                    }, connectTimeoutLocal)
+                }
+            )
+        });
+
+        describe(`assert the file is existed`, () => {
+            [["S255_IR_sci.spw25.cube.I.pbcor.fits", CARTA.FileType.FITS, 7048405440],
+             ["SDC335.579-0.292.spw0.line.image", CARTA.FileType.CASA, 1864975311],
+             ["G34mm1.miriad", CARTA.FileType.MIRIAD, 7829305],
+            ].map(
+                ([file, type, size]) => {
+    
+                    test(`assert the file "${file}" is existed, image type is ${type}, size = ${size}.`, 
+                    done => {
+                        // While receive a message from Websocket server
+                        Connection.onmessage = (event: MessageEvent) => {
+                            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                            if(eventName == "FILE_LIST_RESPONSE"){
+                                const eventId = new Uint32Array(event.data, 32, 1)[0];
+                                const eventData = new Uint8Array(event.data, 36);
+    
+                                let parsedMessage;
+                                parsedMessage = CARTA.FileListResponse.decode(eventData);
+    
+                                let fileInfo = parsedMessage.files.find(f => f.name === file);
+                                expect(fileInfo).toBeDefined();
+                                expect(fileInfo.type).toBe(type);
+                                expect(fileInfo.size.toNumber()).toBe(size);
+                            }
+                            done();
+                        } 
+                    }, connectTimeoutLocal)
+                }
+            )
+        });
+
+    });
+
+    afterAll( done => {
+        Connection.close();
+        done();
+    });
+});

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -3,7 +3,7 @@ import * as Utitlity from "./testUtilityFunction";
 
 let WebSocket = require('ws');
 let testServerUrl = "ws://localhost:50505";
-let expectRootPath = "/home/user/CARTA/Images";
+let expectRootPath = "/home/acdc/CARTA/Images";
 let testSubdirectoryName = `${expectRootPath}/QA`;
 let connectTimeoutLocal = 300;
 
@@ -72,7 +72,7 @@ describe("FILETYPE_PARSER tests", () => {
                 const eventData = new Uint8Array(event.data, 36);
                 expect(CARTA.FileListResponse.decode(eventData).success).toBe(true);
 
-                // console.log(CARTA.FileListResponse.decode(eventData));
+            //    console.log(CARTA.FileListResponse.decode(eventData));
                 console.log(`The root folder on backend is "${CARTA.FileListResponse.decode(eventData).parent}"`);
                     
 
@@ -181,7 +181,7 @@ describe("FILETYPE_PARSER tests", () => {
         });        
         
         describe(`assert the folder is existed in "FILE_LIST_RESPONSE.subdirectory"`, () => {
-            [["empty_folder"], ["empty2.miriad"], ["empty2.fits"], ["empty2.image"], [".."]
+            [["empty_folder"], ["empty2.miriad"], ["empty2.fits"], ["empty2.image"]
             ].map(
                 ([folder]) => {
                     test(`assert the folder "${folder}" is existed.`, 

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -1,5 +1,5 @@
 import {CARTA} from "carta-protobuf";
-import * as Utitlity from "./testUtilityFunction";
+import * as Utility from "./testUtilityFunction";
 
 let WebSocket = require('ws');
 let testServerUrl = "ws://localhost:50505";
@@ -22,7 +22,7 @@ describe("FILETYPE_PARSER tests", () => {
                 let payload = CARTA.RegisterViewer.encode(message).finish();
                 let eventData = new Uint8Array(32 + 4 + payload.byteLength);
 
-                eventData.set(Utitlity.stringToUint8Array("REGISTER_VIEWER", 32));
+                eventData.set(Utility.stringToUint8Array("REGISTER_VIEWER", 32));
                 eventData.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
                 eventData.set(payload, 36);
 
@@ -38,7 +38,7 @@ describe("FILETYPE_PARSER tests", () => {
     done => {
         // While receive a message in the form of arraybuffer
         Connection.onmessage = (event: MessageEvent) => {
-            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+            const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
             if(eventName == "REGISTER_VIEWER_ACK"){
                 // Assertion
                 expect(event.data.byteLength).toBeGreaterThan(0);
@@ -50,7 +50,7 @@ describe("FILETYPE_PARSER tests", () => {
                 let payload = CARTA.FileListRequest.encode(message).finish();
                 const eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
     
-                eventDataTx.set(Utitlity.stringToUint8Array("FILE_LIST_REQUEST", 32));
+                eventDataTx.set(Utility.stringToUint8Array("FILE_LIST_REQUEST", 32));
                 eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
                 eventDataTx.set(payload, 36);
     
@@ -65,7 +65,7 @@ describe("FILETYPE_PARSER tests", () => {
     done => {
         // While receive a message in the form of arraybuffer
         Connection.onmessage = (event: MessageEvent) => {
-            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+            const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
             
             if(eventName == "FILE_LIST_RESPONSE"){
                 expect(event.data.byteLength).toBeGreaterThan(0);
@@ -90,7 +90,7 @@ describe("FILETYPE_PARSER tests", () => {
             let payload = CARTA.FileListRequest.encode(message).finish();
             const eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
 
-            eventDataTx.set(Utitlity.stringToUint8Array("FILE_LIST_REQUEST", 32));
+            eventDataTx.set(Utility.stringToUint8Array("FILE_LIST_REQUEST", 32));
             eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
             eventDataTx.set(payload, 36);
 
@@ -104,7 +104,7 @@ describe("FILETYPE_PARSER tests", () => {
         done => {
             // While receive a message from Websocket server
             Connection.onmessage = (event: MessageEvent) => {
-                const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
                 expect(event.data.byteLength).toBeGreaterThan(40);
                 expect(eventName).toBe("FILE_LIST_RESPONSE");
 
@@ -140,7 +140,7 @@ describe("FILETYPE_PARSER tests", () => {
         done => {
             // While receive a message from Websocket server
             Connection.onmessage = (event: MessageEvent) => {
-                const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
                 if(eventName == "FILE_LIST_RESPONSE"){
                     const eventData = new Uint8Array(event.data, 36);
 
@@ -163,7 +163,7 @@ describe("FILETYPE_PARSER tests", () => {
                     done => {
                         // While receive a message from Websocket server
                         Connection.onmessage = (event: MessageEvent) => {
-                            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                            const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
                             if(eventName == "FILE_LIST_RESPONSE"){
                                 const eventData = new Uint8Array(event.data, 36);
     
@@ -188,7 +188,7 @@ describe("FILETYPE_PARSER tests", () => {
                     done => {
                         // While receive a message from Websocket server
                         Connection.onmessage = (event: MessageEvent) => {
-                            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                            const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
                             if(eventName == "FILE_LIST_RESPONSE"){
                                 const eventData = new Uint8Array(event.data, 36);
     
@@ -216,7 +216,7 @@ describe("FILETYPE_PARSER tests", () => {
                     done => {
                         // While receive a message from Websocket server
                         Connection.onmessage = (event: MessageEvent) => {
-                            const eventName = Utitlity.getEventName(new Uint8Array(event.data, 0, 32));
+                            const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
                             if(eventName == "FILE_LIST_RESPONSE"){
                                 const eventData = new Uint8Array(event.data, 36);
     

--- a/src/test/FILETYPE_PARSER.test.ts
+++ b/src/test/FILETYPE_PARSER.test.ts
@@ -212,7 +212,7 @@ describe("FILETYPE_PARSER tests", () => {
             ].map(
                 ([file, type, size]) => {
     
-                    test(`assert the file "${file}" is existed, image type is ${type}, size = ${size}.`, 
+                    test(`assert the file "${file}" is existed, image type is ${CARTA.FileType[type]}, size = ${size}.`, 
                     done => {
                         // While receive a message from Websocket server
                         Connection.onmessage = (event: MessageEvent) => {


### PR DESCRIPTION
According to test ICD [carta_ICD_testCases](https://docs.google.com/document/d/1CDa3tpBxKZX8xX2dopKHsYbVwUFZkKHJAYV-ugH4_MQ/edit?ts=5bc715d1), the test "FILETYPE_PARSER" gives a testing helper for the event FILE_LIST_REQUEST & FILE_LIST_RESPONSE on [CARTA ICD](https://docs.google.com/document/d/1V4KzJaV3zQYJoA_ims28iBTit_aixo_xYcAfPiq8hic/edit#heading=h.58ke5sat0rfq).