### PR TITLE
Add testing: CURSOR_XY_PROFILE.

### DIFF
--- a/src/test/CURSOR_XY_PROFILE.test.ts
+++ b/src/test/CURSOR_XY_PROFILE.test.ts
@@ -1,0 +1,359 @@
+import {CARTA} from "carta-protobuf";
+import * as Utility from "./testUtilityFunction";
+
+let WebSocket = require("ws");
+let testServerUrl = "ws://localhost:50505";
+let expectRootPath = "/Users/zarda/CARTA/Images";
+// let testSubdirectoryName = "QA"; // for NRAO backend
+let testSubdirectoryName = `${expectRootPath}/QA`; // ASIAA backend
+let connectionTimeout = 1000;
+let testFileName = "qa_xyProfiler.fits";
+
+describe("CURSOR_XY_PROFILE tests", () => {   
+    let Connection: WebSocket;
+
+    beforeEach( done => {
+        // Establish a websocket connection in the binary form: arraybuffer 
+        Connection = new WebSocket(testServerUrl);
+        Connection.binaryType = "arraybuffer";
+        // While open a Websocket
+        Connection.onopen = () => {
+            // Checkout if Websocket server is ready
+            if (Connection.readyState === WebSocket.OPEN) {
+                // Preapare the message on a eventData
+                const message = CARTA.RegisterViewer.create({sessionId: "", apiKey: "1234"});
+                let payload = CARTA.RegisterViewer.encode(message).finish();
+                let eventData = new Uint8Array(32 + 4 + payload.byteLength);
+
+                eventData.set(Utility.stringToUint8Array("REGISTER_VIEWER", 32));
+                eventData.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                eventData.set(payload, 36);
+
+                Connection.send(eventData);
+            } else {
+                console.log(`Can not open a connection.`);
+            }
+            done();
+        };
+    }, connectionTimeout);
+
+    test(`connect to CARTA "${testServerUrl}" & ...`, 
+    done => {
+        // While receive a message in the form of arraybuffer
+        Connection.onmessage = (event: MessageEvent) => {
+            const eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
+            if (eventName === "REGISTER_VIEWER_ACK") {
+                expect(event.data.byteLength).toBeGreaterThan(0);
+                const eventData = new Uint8Array(event.data, 36);
+                expect(CARTA.RegisterViewerAck.decode(eventData).success).toBe(true);
+                
+                done();
+            }
+        };
+    }, connectionTimeout);
+
+    describe(`access directory`, () => {
+        [[expectRootPath], [testSubdirectoryName]
+        ].map(
+            ([dir]) => {
+                test(`assert the directory "${dir}" opens.`, 
+                done => {
+                    // Preapare the message
+                    let message = CARTA.FileListRequest.create({directory: testSubdirectoryName});
+                    let payload = CARTA.FileListRequest.encode(message).finish();
+                    let eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+            
+                    eventDataTx.set(Utility.stringToUint8Array("FILE_LIST_REQUEST", 32));
+                    eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                    eventDataTx.set(payload, 36);
+            
+                    Connection.send(eventDataTx);
+            
+                    // While receive a message
+                    Connection.onmessage = (event: MessageEvent) => {
+                        let eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
+                        if (eventName === "FILE_LIST_RESPONSE") {
+                            expect(event.data.byteLength).toBeGreaterThan(0);
+                            let eventData = new Uint8Array(event.data, 36);
+                            expect(CARTA.FileListResponse.decode(eventData).success).toBe(true);
+            
+                            done();
+                        }
+                    };
+                }, connectionTimeout);
+            }
+        );
+    });
+
+    describe(`open the file "${testFileName}"`, () => {
+        test(`assert the file "${testFileName}" loads info.`, 
+        done => {
+            // Preapare the message
+            let message = CARTA.FileListRequest.create({directory: testSubdirectoryName});
+            let payload = CARTA.FileListRequest.encode(message).finish();
+            let eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+    
+            eventDataTx.set(Utility.stringToUint8Array("FILE_LIST_REQUEST", 32));
+            eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+            eventDataTx.set(payload, 36);
+    
+            Connection.send(eventDataTx);
+    
+            // While receive a message
+            Connection.onmessage = (event: MessageEvent) => {
+                let eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
+                if (eventName === "FILE_LIST_RESPONSE") {
+                    let eventData = new Uint8Array(event.data, 36);
+                    expect(CARTA.FileListResponse.decode(eventData).success).toBe(true);
+
+                    // Preapare the message
+                    message = CARTA.FileInfoRequest.create({
+                        directory: testSubdirectoryName, file: testFileName, hdu: ""});
+                    payload = CARTA.FileInfoRequest.encode(message).finish();
+                    eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+
+                    eventDataTx.set(Utility.stringToUint8Array("FILE_INFO_REQUEST", 32));
+                    eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                    eventDataTx.set(payload, 36);
+
+                    Connection.send(eventDataTx);
+
+                    // While receive a message
+                    Connection.onmessage = (eventInfo: MessageEvent) => {
+                        eventName = Utility.getEventName(new Uint8Array(eventInfo.data, 0, 32));
+                        if (eventName === "FILE_INFO_RESPONSE") {
+                            eventData = new Uint8Array(eventInfo.data, 36);
+                            let fileInfoMessage = CARTA.FileInfoResponse.decode(eventData);
+                            // console.log(fileInfoMessage.fileInfoExtended);
+                            expect(fileInfoMessage.success).toBe(true);
+                            done();
+                        } // if
+                    }; // onmessage
+                } // if
+            }; // onmessage "FILE_LIST_RESPONSE"
+        }, connectionTimeout); // test
+
+        test(`assert the file "${testFileName}" opens.`, 
+        done => {
+            // Preapare the message
+            let message = CARTA.FileListRequest.create({directory: testSubdirectoryName});
+            let payload = CARTA.FileListRequest.encode(message).finish();
+            let eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+    
+            eventDataTx.set(Utility.stringToUint8Array("FILE_LIST_REQUEST", 32));
+            eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+            eventDataTx.set(payload, 36);
+    
+            Connection.send(eventDataTx);
+    
+            // While receive a message
+            Connection.onmessage = (event: MessageEvent) => {
+                let eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
+                if (eventName === "FILE_LIST_RESPONSE") {
+                    let eventData = new Uint8Array(event.data, 36);
+                    expect(CARTA.FileListResponse.decode(eventData).success).toBe(true);
+
+                    // Preapare the message
+                    message = CARTA.OpenFile.create({
+                        directory: testSubdirectoryName, 
+                        file: testFileName, hdu: "", fileId: 0, 
+                        renderMode: CARTA.RenderMode.RASTER
+                    });
+                    payload = CARTA.OpenFile.encode(message).finish();
+                    eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+
+                    eventDataTx.set(Utility.stringToUint8Array("OPEN_FILE", 32));
+                    eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                    eventDataTx.set(payload, 36);
+
+                    Connection.send(eventDataTx);
+
+                    // While receive a message
+                    Connection.onmessage = (eventOpen: MessageEvent) => {
+                        eventName = Utility.getEventName(new Uint8Array(eventOpen.data, 0, 32));
+                        if (eventName === "OPEN_FILE_ACK") {
+                            eventData = new Uint8Array(eventOpen.data, 36);
+                            let openFileMessage = CARTA.OpenFileAck.decode(eventData);
+                            // console.log(openFileMessage);
+                            expect(openFileMessage.success).toBe(true);
+
+                            done();
+                        } // if
+                    }; // onmessage
+                } // if
+            }; // onmessage "FILE_LIST_RESPONSE"
+        }, connectionTimeout); // test
+    }); // describe
+
+    describe(`open the file "${testFileName} and ...`, 
+    () => {
+        beforeEach( 
+        done => {
+            Connection.onmessage = (event: MessageEvent) => {
+                let eventName = Utility.getEventName(new Uint8Array(event.data, 0, 32));
+                if (eventName === "REGISTER_VIEWER_ACK") {
+                    // Assertion
+                    let eventData = new Uint8Array(event.data, 36);
+                    expect(CARTA.RegisterViewerAck.decode(eventData).success).toBe(true);
+
+                    // Preapare the message
+                    let message = CARTA.OpenFile.create({
+                        directory: testSubdirectoryName, 
+                        file: testFileName, hdu: "", fileId: 0, 
+                        renderMode: CARTA.RenderMode.RASTER
+                    });
+                    let payload = CARTA.OpenFile.encode(message).finish();
+                    let eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+
+                    eventDataTx.set(Utility.stringToUint8Array("OPEN_FILE", 32));
+                    eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                    eventDataTx.set(payload, 36);
+
+                    Connection.send(eventDataTx);
+
+                    done();
+                }                
+            };    
+        }, connectionTimeout);       
+        
+        describe(`get the xy profiles at different cursor positions`, () => {
+            [[0, {x: 50.00, y: 50.00}, {x: 50.00, y: 50.00}, {x: 100, y: 100}, 1],
+             [0, {x: 49.50, y: 49.50}, {x: 50.00, y: 50.00}, {x: 100, y: 100}, 1],
+             [0, {x: 49.50, y: 50.49}, {x: 50.00, y: 50.00}, {x: 100, y: 100}, 1],
+             [0, {x: 50.49, y: 49.50}, {x: 50.00, y: 50.00}, {x: 100, y: 100}, 1],
+             [0, {x: 50.49, y: 50.49}, {x: 50.00, y: 50.00}, {x: 100, y: 100}, 1],
+             [0, {x:  0.00, y:  0.00}, {x:  0.00, y:  0.00}, {x: 100, y: 100}, 1],
+             [0, {x:  0.00, y: 99.00}, {x:  0.00, y: 99.00}, {x: 100, y: 100}, 0],
+             [0, {x: 99.00, y:  0.00}, {x: 99.00, y:  0.00}, {x: 100, y: 100}, 0],
+             [0, {x: 99.00, y: 99.00}, {x: 99.00, y: 99.00}, {x: 100, y: 100}, 1],
+            ].map(
+                function([fileID, point, assertPoint, profileLen, value]: 
+                        [number, {x: number, y: number}, {x: number, y: number}, {x: number, y: number}, number]) {
+                    test(`assert the fileID "${fileID}" returns: Value=${value}, Profile length={${profileLen.x}, ${profileLen.y}}, Point={${assertPoint.x}, ${assertPoint.y}} as acquireing {${point.x}, ${point.y}}.`, 
+                    done => {
+                        Connection.onmessage = (eventOpen: MessageEvent) => {
+                            let eventName = Utility.getEventName(new Uint8Array(eventOpen.data, 0, 32));
+                            if (eventName === "OPEN_FILE_ACK") {
+                                let eventData = new Uint8Array(eventOpen.data, 36);
+                                expect(CARTA.OpenFileAck.decode(eventData).success).toBe(true);
+    
+                                // Preapare the message
+                                const message = CARTA.SetCursor.create({fileId: fileID, point: point});
+                                let payload = CARTA.SetCursor.encode(message).finish();
+                                const eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+    
+                                eventDataTx.set(Utility.stringToUint8Array("SET_CURSOR", 32));
+                                eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                                eventDataTx.set(payload, 36);
+    
+                                Connection.send(eventDataTx);
+
+                                // While receive a message
+                                Connection.onmessage = (eventInfo: MessageEvent) => {
+                                    eventName = Utility.getEventName(new Uint8Array(eventInfo.data, 0, 32));
+                                    if (eventName === "SPATIAL_PROFILE_DATA") {
+                                        eventData = new Uint8Array(eventInfo.data, 36);
+                                        let spatialProfileDataMessage = CARTA.SpatialProfileData.decode(eventData);
+                                        // console.log(spatialProfileDataMessage);
+                                        
+                                        expect(spatialProfileDataMessage.fileId).toEqual(fileID);
+                                        expect(spatialProfileDataMessage.value).toEqual(value);
+                                        expect(spatialProfileDataMessage.x).toEqual(assertPoint.x);
+                                        expect(spatialProfileDataMessage.y).toEqual(assertPoint.y);
+
+                                        let spatialProfileDataMessageProfileX = spatialProfileDataMessage.profiles.find(f => f.coordinate === "x").values;
+                                        expect(spatialProfileDataMessageProfileX.length).toEqual(profileLen.x);
+                                        let spatialProfileDataMessageProfileY = spatialProfileDataMessage.profiles.find(f => f.coordinate === "y").values;
+                                        expect(spatialProfileDataMessageProfileY.length).toEqual(profileLen.y);
+
+                                        done();
+                                    } // if
+                                }; // onmessage
+                            } // if
+                        }; // onmessage                        
+                    } // done
+                    , connectionTimeout); // test
+                } // function([ ])
+            ); // map
+        }); // describe
+
+        describe(`get the xy profiles at different cursor positions`, () => {
+            [[0, {x: 50.00, y: 50.00}, {idx: 50, value: 1, others: 0}, {idx: 50, value: 1, others: 0}],
+             [0, {x:  0.00, y:  0.00}, {idx:  0, value: 1, others: 0}, {idx:  0, value: 1, others: 0}],
+             [0, {x:  0.00, y: 99.00}, {idx: 99, value: 1, others: 0}, {idx:  0, value: 1, others: 0}],
+             [0, {x: 99.00, y:  0.00}, {idx:  0, value: 1, others: 0}, {idx: 99, value: 1, others: 0}],
+             [0, {x: 99.00, y: 99.00}, {idx: 99, value: 1, others: 0}, {idx: 99, value: 1, others: 0}],
+            ].map(
+                function([fileID, point, oddPointX, oddPointY]: 
+                        [number, {x: number, y: number}, {idx: number, value: number, others: number}, {idx: number, value: number, others: number}]) {
+                    test(`assert the profile in fileID "${fileID}" has: 
+                    the ${oddPointX.idx}th value = ${oddPointX.value} with other values = ${oddPointX.others} on the profile_x & 
+                    the ${oddPointY.idx}th value = ${oddPointY.value} with other values = ${oddPointY.others} on the profile_y as acquireing {${point.x}, ${point.y}}.`, 
+                    done => {
+                        Connection.onmessage = (eventOpen: MessageEvent) => {
+                            let eventName = Utility.getEventName(new Uint8Array(eventOpen.data, 0, 32));
+                            if (eventName === "OPEN_FILE_ACK") {
+                                let eventData = new Uint8Array(eventOpen.data, 36);
+                                expect(CARTA.OpenFileAck.decode(eventData).success).toBe(true);
+    
+                                // Preapare the message
+                                const message = CARTA.SetCursor.create({fileId: fileID, point: point});
+                                let payload = CARTA.SetCursor.encode(message).finish();
+                                const eventDataTx = new Uint8Array(32 + 4 + payload.byteLength);
+    
+                                eventDataTx.set(Utility.stringToUint8Array("SET_CURSOR", 32));
+                                eventDataTx.set(new Uint8Array(new Uint32Array([1]).buffer), 32);
+                                eventDataTx.set(payload, 36);
+    
+                                Connection.send(eventDataTx);
+
+                                // While receive a message
+                                Connection.onmessage = (eventInfo: MessageEvent) => {
+                                    eventName = Utility.getEventName(new Uint8Array(eventInfo.data, 0, 32));
+                                    if (eventName === "SPATIAL_PROFILE_DATA") {
+                                        eventData = new Uint8Array(eventInfo.data, 36);
+                                        let spatialProfileDataMessage = CARTA.SpatialProfileData.decode(eventData);
+                                        // console.log(spatialProfileDataMessage);
+
+                                        // Assert about profile x
+                                        let spatialProfileDataMessageProfileX = 
+                                                spatialProfileDataMessage.profiles.find(f => f.coordinate === "x").values;
+                                        for (let i = 0; i < spatialProfileDataMessageProfileX.length; i++) {
+                                            const testValue = spatialProfileDataMessageProfileX[i];
+                                            if (i === oddPointX.idx) {
+                                                expect(testValue).toEqual(oddPointX.value);
+                                            } else {
+                                                expect(testValue).toEqual(oddPointX.others);
+                                            }
+                                        }
+
+                                        // Assert about profile y
+                                        let spatialProfileDataMessageProfileY = 
+                                                spatialProfileDataMessage.profiles.find(f => f.coordinate === "y").values;
+                                        for (let i = 0; i < spatialProfileDataMessageProfileY.length; i++) {
+                                            const testValue = spatialProfileDataMessageProfileY[i];
+                                            if (i === oddPointY.idx) {
+                                                expect(testValue).toEqual(oddPointY.value);
+                                            } else {
+                                                expect(testValue).toEqual(oddPointY.others);
+                                            }
+                                        }
+
+                                        done();
+                                    } // if
+                                }; // onmessage
+                            } // if
+                        }; // onmessage                        
+                    } // done
+                    , connectionTimeout); // test
+                } // function([ ])
+            ); // map
+        }); // describe
+
+    });
+
+    afterEach( done => {
+        Connection.close();
+        done();
+    });
+});


### PR DESCRIPTION
According to [test ICD,](https://docs.google.com/document/d/1CDa3tpBxKZX8xX2dopKHsYbVwUFZkKHJAYV-ugH4_MQ/edit?ts=5bc715d1) the test "CURSOR_XY_PROFILE" gives a testing helper for implementing the event SET_CURSOR & SPATIAL_PROFILER_DATA on [CARTA ICD](https://docs.google.com/document/d/1V4KzJaV3zQYJoA_ims28iBTit_aixo_xYcAfPiq8hic/edit#heading=h.sgxhpgbn2sks).