### PR TITLE
cursor info freq

### DIFF
--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -27,9 +27,6 @@ class CursorOverlayProps {
 export class CursorOverlayComponent extends React.PureComponent<CursorOverlayProps> {
 
     render() {
-
-        console.log(this.props.spectralInfo);
-
         const cursorInfo = this.props.cursorInfo;
         let infoStrings: string[] = [];
         if (this.props.showWCS && cursorInfo.infoWCS) {

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import "./CursorOverlayComponent.css";
-import {CursorInfo} from "../../../models/CursorInfo";
+import {CursorInfo, SpectralInfo} from "../../../models";
 import {CSSProperties} from "react";
 
 class CursorOverlayProps {
     cursorInfo: CursorInfo;
+    spectralInfo: SpectralInfo;
     docked: boolean;
     mip: number;
     width: number;
@@ -19,25 +20,29 @@ class CursorOverlayProps {
     showImage?: boolean;
     showValue?: boolean;
     showCanvas?: boolean;
-
+    showChannel?: boolean;
+    showSpectral?: boolean;
 }
 
 export class CursorOverlayComponent extends React.PureComponent<CursorOverlayProps> {
 
     render() {
+
+        console.log(this.props.spectralInfo);
+
         const cursorInfo = this.props.cursorInfo;
         let infoStrings: string[] = [];
         if (this.props.showWCS && cursorInfo.infoWCS) {
-            infoStrings.push(`WCS: (${cursorInfo.infoWCS.x}, ${cursorInfo.infoWCS.y})`);
+            infoStrings.push(`WCS:\u00a0(${cursorInfo.infoWCS.x},\u00a0${cursorInfo.infoWCS.y})`);
         }
         if (this.props.showCanvas) {
-            infoStrings.push(`Canvas: (${cursorInfo.posCanvasSpace.x.toFixed(0)}, ${cursorInfo.posCanvasSpace.y.toFixed(0)})`);
+            infoStrings.push(`Canvas:\u00a0(${cursorInfo.posCanvasSpace.x.toFixed(0)},\u00a0${cursorInfo.posCanvasSpace.y.toFixed(0)})`);
         }
         if (this.props.showImage) {
-            infoStrings.push(`Image: (${cursorInfo.posImageSpace.x.toFixed(0)}, ${cursorInfo.posImageSpace.y.toFixed(0)})`);
+            infoStrings.push(`Image:\u00a0(${cursorInfo.posImageSpace.x.toFixed(0)},\u00a0${cursorInfo.posImageSpace.y.toFixed(0)})`);
         }
         if (this.props.showValue && this.props.cursorInfo.value !== undefined) {
-            let valueString = `Value: ${this.expo(this.props.cursorInfo.value, 5, this.props.unit, true, true)}`;
+            let valueString = `Value:\u00a0${this.expo(this.props.cursorInfo.value, 5, this.props.unit, true, true)}`;
             if (this.props.mip > 1) {
                 valueString += ` [${this.props.mip}\u00D7${this.props.mip} average]`;
             }
@@ -46,12 +51,23 @@ export class CursorOverlayComponent extends React.PureComponent<CursorOverlayPro
             }
             infoStrings.push(valueString);
         }
+        if (this.props.showChannel && this.props.spectralInfo.channel !== undefined) {
+            infoStrings.push(`Channel:\u00a0${this.props.spectralInfo.channel}`);
+        }
+        if (this.props.showSpectral && this.props.spectralInfo.spectralString) {
+            infoStrings.push(this.props.spectralInfo.spectralString);
+            if (this.props.spectralInfo.freqString) {
+                infoStrings.push(this.props.spectralInfo.freqString);
+            }
+            if (this.props.spectralInfo.velocityString) {
+                infoStrings.push(this.props.spectralInfo.velocityString);
+            }
+        }
 
         const height = (this.props.height !== undefined && this.props.height >= 0) ? this.props.height : 20;
         let top = 0;
 
         let styleProps: CSSProperties = {
-            height: height,
             lineHeight: height + "px"
         };
 
@@ -61,8 +77,7 @@ export class CursorOverlayComponent extends React.PureComponent<CursorOverlayPro
 
         if (this.props.top !== undefined) {
             styleProps.top = this.props.top;
-        }
-        else if (this.props.bottom !== undefined) {
+        } else if (this.props.bottom !== undefined) {
             styleProps.bottom = this.props.bottom;
         }
 

--- a/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
+++ b/src/components/ImageView/CursorOverlay/CursorOverlayComponent.tsx
@@ -44,7 +44,7 @@ export class CursorOverlayComponent extends React.PureComponent<CursorOverlayPro
         if (this.props.showValue && this.props.cursorInfo.value !== undefined) {
             let valueString = `Value:\u00a0${this.expo(this.props.cursorInfo.value, 5, this.props.unit, true, true)}`;
             if (this.props.mip > 1) {
-                valueString += ` [${this.props.mip}\u00D7${this.props.mip} average]`;
+                valueString += ` [${this.props.mip}\u00D7${this.props.mip}\u00a0average]`;
             }
             if (isNaN(this.props.cursorInfo.value)) {
                 valueString = "NaN";

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -94,7 +94,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                     showImage={true}
                     showWCS={true}
                     showValue={true}
-                    showChannel={true}
+                    showChannel={false}
                     showSpectral={true}
                 />
                 }

--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -83,6 +83,7 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                 {appStore.astReady && appStore.activeFrame && appStore.cursorInfo &&
                 <CursorOverlayComponent
                     cursorInfo={appStore.cursorInfo}
+                    spectralInfo={appStore.activeFrame.spectralInfo}
                     mip={appStore.activeFrame.currentFrameView.mip}
                     width={appStore.overlayStore.viewWidth}
                     left={appStore.overlayStore.padding.left}
@@ -93,6 +94,8 @@ export class ImageViewComponent extends React.Component<WidgetProps> {
                     showImage={true}
                     showWCS={true}
                     showValue={true}
+                    showChannel={true}
+                    showSpectral={true}
                 />
                 }
                 {!appStore.astReady &&

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -87,8 +87,9 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         if (!this.widgetStore.useWcsValues) {
             channelInfo = {
                 fromWCS: false,
-                channelType: {unit: "", code: "", type: "Channel"},
-                values: new Array<number>(this.frame.frameInfo.fileInfoExtended.depth)
+                channelType: {unit: "", code: "", name: "Channel"},
+                values: new Array<number>(this.frame.frameInfo.fileInfoExtended.depth),
+                rawValues: new Array<number>(this.frame.frameInfo.fileInfoExtended.depth)
             };
 
             for (let i = 0; i < channelInfo.values.length; i++) {
@@ -252,7 +253,7 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
                                 horizontal: false,
                             }];
                         }
-                        let channelLabel = channelInfo.channelType.type;
+                        let channelLabel = channelInfo.channelType.name;
                         if (channelInfo.channelType.unit && channelInfo.channelType.unit.length) {
                             channelLabel += ` (${channelInfo.channelType.unit})`;
                         }

--- a/src/models/ChannelInfo.ts
+++ b/src/models/ChannelInfo.ts
@@ -1,0 +1,8 @@
+import {ChannelType} from "./ChannelType";
+
+export interface ChannelInfo {
+    fromWCS: boolean;
+    channelType: ChannelType;
+    values: number[];
+    rawValues: number[];
+}

--- a/src/models/ChannelType.ts
+++ b/src/models/ChannelType.ts
@@ -1,0 +1,19 @@
+export interface ChannelType {
+    code: string;
+    unit?: string;
+    name: string;
+}
+
+// From FITS standard (Table 25 of V4.0 of "Definition of the Flexible Image Transport System")
+export const CHANNEL_TYPES: ChannelType[] = [
+    {code: "FREQ", name: "Frequency", unit: "Hz"},
+    {code: "ENER", name: "Energy", unit: "J"},
+    {code: "WAVN", name: "Wavenumber", unit: "1/m"},
+    {code: "VRAD", name: "Velocity", unit: "m/s"},
+    {code: "WAVE", name: "Vacuum wavelength", unit: "m"},
+    {code: "VOPT", name: "Velocity\u00a0(OPT)", unit: "m/s"},
+    {code: "ZOPT", name: "Redshift"},
+    {code: "AWAV", name: "Air wavelength", unit: "m"},
+    {code: "VELO", name: "Velocity\u00a0(Radial)", unit: "m/s"},
+    {code: "BETA", name: "Beta"},
+];

--- a/src/models/CursorInfo.ts
+++ b/src/models/CursorInfo.ts
@@ -1,6 +1,6 @@
 import {Point2D} from "./Point2D";
 
-export class CursorInfo {
+export interface CursorInfo {
     posCanvasSpace: Point2D;
     posImageSpace: Point2D;
     posWCS: Point2D;

--- a/src/models/FrameView.ts
+++ b/src/models/FrameView.ts
@@ -1,0 +1,7 @@
+export interface FrameView {
+    xMin: number;
+    xMax: number;
+    yMin: number;
+    yMax: number;
+    mip: number;
+}

--- a/src/models/SpectralInfo.ts
+++ b/src/models/SpectralInfo.ts
@@ -1,0 +1,9 @@
+import {ChannelType} from "./ChannelType";
+
+export interface SpectralInfo {
+    channel: number;
+    channelType: ChannelType;
+    spectralString: string;
+    freqString?: string;
+    velocityString?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,6 @@
+export * from "./CursorInfo";
+export * from "./ChannelInfo";
+export * from "./ChannelType";
+export * from "./FrameView";
+export * from "./Point2D";
+export * from "./SpectralInfo";

--- a/src/stores/AppStore.ts
+++ b/src/stores/AppStore.ts
@@ -1,21 +1,19 @@
 import {action, autorun, computed, observable} from "mobx";
+import * as AST from "ast_wrapper";
+import * as _ from "lodash";
 import {OverlayStore, dayPalette, nightPalette} from "./OverlayStore";
 import {SpatialProfileStore} from "./SpatialProfileStore";
 import {FileBrowserStore} from "./FileBrowserStore";
-import {FrameInfo, FrameStore, FrameView} from "./FrameStore";
+import {FrameInfo, FrameStore} from "./FrameStore";
 import {AlertStore} from "./AlertStore";
 import {LogEntry, LogStore} from "./LogStore";
 import {BackendService} from "../services/BackendService";
-import {CursorInfo} from "../models/CursorInfo";
+import {CursorInfo, FrameView} from "../models";
 import {CARTA} from "carta-protobuf";
-import * as AST from "ast_wrapper";
-import * as _ from "lodash";
 import {AnimationState, AnimatorStore} from "./AnimatorStore";
-import SpatialProfile = CARTA.SpatialProfile;
-import {smoothStepOffset} from "../util/math";
+import {smoothStepOffset} from "../util";
 import {WidgetsStore} from "./WidgetsStore";
 import {SpectralProfileStore} from "./SpectralProfileStore";
-import SpectralProfile = CARTA.SpectralProfile;
 
 export class AppStore {
     // Backend service
@@ -352,7 +350,7 @@ export class AppStore {
                 profileStore.approximate = false;
                 const profileMap = new Map<string, CARTA.SpatialProfile>();
                 for (let profile of spatialProfileData.profiles) {
-                    profileMap.set(profile.coordinate, profile as SpatialProfile);
+                    profileMap.set(profile.coordinate, profile as CARTA.SpatialProfile);
                 }
                 profileStore.setProfiles(profileMap);
             }
@@ -372,7 +370,7 @@ export class AppStore {
                 profileStore.stokes = spectralProfileData.stokes;
                 const profileMap = new Map<string, CARTA.SpectralProfile>();
                 for (let profile of spectralProfileData.profiles) {
-                    profileMap.set(profile.coordinate, profile as SpectralProfile);
+                    profileMap.set(profile.coordinate, profile as CARTA.SpectralProfile);
                 }
                 profileStore.setProfiles(profileMap);
             }

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -152,7 +152,7 @@ export class FrameStore {
 
                     for (let i = 0; i < N; i++) {
                         // FITS standard uses 1 for the first pixel
-                        const channelOffset = i - 1 - refPix;
+                        const channelOffset = i + 1 - refPix;
                         rawValues[i] = (channelOffset * delta + refVal);
                         values[i] = rawValues[i] * scalingFactor;
                     }

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -191,7 +191,7 @@ export class FrameStore {
                 } else {
                     spectralName = channelInfo.channelType.name;
                 }
-                spectralInfo.spectralString = `${spectralName}:\u00a0${channelInfo.values[this.channel].toFixed(2)}\u00a0${channelInfo.channelType.unit}`;
+                spectralInfo.spectralString = `${spectralName}:\u00a0${channelInfo.values[this.channel].toFixed(4)}\u00a0${channelInfo.channelType.unit}`;
 
 
                 const refFreq = this.referenceFrequency;

--- a/src/stores/FrameStore.ts
+++ b/src/stores/FrameStore.ts
@@ -179,18 +179,30 @@ export class FrameStore {
         if (this.frameInfo.fileInfoExtended.depth > 1) {
             const channelInfo = this.channelInfo;
             if (channelInfo.channelType.code) {
+                let specSysValue = "";
+                const specSysHeader = this.frameInfo.fileInfoExtended.headerEntries.find(entry => entry.name.indexOf(`SPECSYS`) !== -1);
+                if (specSysHeader && specSysHeader.value) {
+                    specSysValue = specSysHeader.value;
+                }
                 spectralInfo.channelType = channelInfo.channelType;
-                spectralInfo.spectralString = `${channelInfo.channelType.name}:\u00a0${channelInfo.values[this.channel].toFixed(2)}\u00a0${channelInfo.channelType.unit}`;
-            }
+                let spectralName;
+                if (specSysValue) {
+                    spectralName = `${channelInfo.channelType.name}\u00a0(${specSysValue})`;
+                } else {
+                    spectralName = channelInfo.channelType.name;
+                }
+                spectralInfo.spectralString = `${spectralName}:\u00a0${channelInfo.values[this.channel].toFixed(2)}\u00a0${channelInfo.channelType.unit}`;
 
-            const refFreq = this.referenceFrequency;
-            // Add velocity conversion
-            if (channelInfo.channelType.code === "FREQ" && isFinite(refFreq)) {
-                const freqVal = channelInfo.rawValues[this.channel];
-                spectralInfo.velocityString = velocityStringFromFrequency(freqVal, refFreq);
-            } else if (channelInfo.channelType.code === "VRAD") {
-                const velocityVal = channelInfo.rawValues[this.channel];
-                spectralInfo.freqString = frequencyStringFromVelocity(velocityVal, refFreq);
+
+                const refFreq = this.referenceFrequency;
+                // Add velocity conversion
+                if (channelInfo.channelType.code === "FREQ" && isFinite(refFreq)) {
+                    const freqVal = channelInfo.rawValues[this.channel];
+                    spectralInfo.velocityString = velocityStringFromFrequency(freqVal, refFreq);
+                } else if (channelInfo.channelType.code === "VRAD") {
+                    const velocityVal = channelInfo.rawValues[this.channel];
+                    spectralInfo.freqString = frequencyStringFromVelocity(velocityVal, refFreq);
+                }
             }
         }
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,2 @@
+export * from "./math";
+export * from "./units";

--- a/src/util/units.ts
+++ b/src/util/units.ts
@@ -6,7 +6,7 @@ export function velocityFromFrequency(freq: number, refFreq: number): number {
 export function velocityStringFromFrequency(freq: number, refFreq: number): string {
     if (isFinite(refFreq)) {
         const velocityVal = velocityFromFrequency(freq, refFreq);
-        return `Velocity:\u00a0${(velocityVal * 1e-3).toFixed(2)}\u00a0km/s`;
+        return `Velocity:\u00a0${(velocityVal * 1e-3).toFixed(4)}\u00a0km/s`;
     }
     return null;
 }
@@ -19,7 +19,7 @@ export function frequencyFromVelocity(velocity: number, refFreq: number): number
 export function frequencyStringFromVelocity(velocity: number, refFreq: number): string {
     if (isFinite(refFreq)) {
         const frequencyVal = frequencyFromVelocity(velocity, refFreq);
-        return `Frequency:\u00a0${(frequencyVal * 1e-9).toFixed()}\u00a0GHz`;
+        return `Frequency:\u00a0${(frequencyVal * 1e-9).toFixed(4)}\u00a0GHz`;
     }
     return null;
 }

--- a/src/util/units.ts
+++ b/src/util/units.ts
@@ -1,0 +1,25 @@
+export function velocityFromFrequency(freq: number, refFreq: number): number {
+    const c = 299792458;
+    return c * (1.0 - freq / refFreq);
+}
+
+export function velocityStringFromFrequency(freq: number, refFreq: number): string {
+    if (isFinite(refFreq)) {
+        const velocityVal = velocityFromFrequency(freq, refFreq);
+        return `Velocity:\u00a0${(velocityVal * 1e-3).toFixed(2)}\u00a0km/s`;
+    }
+    return null;
+}
+
+export function frequencyFromVelocity(velocity: number, refFreq: number): number {
+    const c = 299792458;
+    return refFreq * (1.0 - velocity / c);
+}
+
+export function frequencyStringFromVelocity(velocity: number, refFreq: number): string {
+    if (isFinite(refFreq)) {
+        const frequencyVal = frequencyFromVelocity(velocity, refFreq);
+        return `Frequency:\u00a0${(frequencyVal * 1e-9).toFixed()}\u00a0GHz`;
+    }
+    return null;
+}


### PR DESCRIPTION
This PR adds spectral info to the cursor

- For images without any spectral info, only the channel index is used
- For images with spectral info, the spectral value of the current channel is used
- For images with a valid SPECSYS keyword, the spectral system is also displayed
- For images with a valid rest frequency and a spectral type of "FREQ", conversions to (radio) velocity are displayed
- For images with a valid rest frequency and a spectral type of "VRAD", conversions to frequency