### PR TITLE
Confluence/save profiles

### DIFF
--- a/src/components/ImageView/ImageViewComponent.tsx
+++ b/src/components/ImageView/ImageViewComponent.tsx
@@ -10,7 +10,7 @@ import {RasterViewComponent} from "./RasterView/RasterViewComponent";
 import {ToolbarComponent} from "./Toolbar/ToolbarComponent";
 import "./ImageViewComponent.css";
 
-export const exportImage = (padding, darkTheme) => {
+export const exportImage = (padding, darkTheme, imageName) => {
     const rasterCanvas = document.getElementById("raster-canvas") as HTMLCanvasElement;
     const overlayCanvas = document.getElementById("overlay-canvas") as HTMLCanvasElement;
     
@@ -33,7 +33,7 @@ export const exportImage = (padding, darkTheme) => {
     
     const a = document.createElement("a") as HTMLAnchorElement;
     a.href = dataURL;
-    a.download = `CARTA-exported-image-${timestamp}.png`;
+    a.download = `${imageName}-image-${timestamp}.png`;
     a.dispatchEvent(new MouseEvent("click"));
 };
 

--- a/src/components/ImageView/Toolbar/ToolbarComponent.tsx
+++ b/src/components/ImageView/Toolbar/ToolbarComponent.tsx
@@ -52,7 +52,7 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
                     <Button icon="numerical" active={!overlay.labelsHidden} onClick={overlay.toggleLabels}/>
                 </Tooltip>
                 <Tooltip content="Export image">
-                    <Button icon="floppy-disk" onClick={() => exportImage(overlay.padding, appStore.darkTheme)}/>
+                    <Button icon="floppy-disk" onClick={() => exportImage(overlay.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}/>
                 </Tooltip>
             </ButtonGroup>
         );

--- a/src/components/Menu/RootMenuComponent.tsx
+++ b/src/components/Menu/RootMenuComponent.tsx
@@ -38,7 +38,7 @@ export class RootMenuComponent extends React.Component<{ appStore: AppStore }> {
                     icon={"media"}
                     label={`${modString}E`}
                     disabled={appStore.backendService.connectionStatus !== ConnectionStatus.ACTIVE || !appStore.activeFrame}
-                    onClick={() => exportImage(appStore.overlayStore.padding, appStore.darkTheme)}
+                    onClick={() => exportImage(appStore.overlayStore.padding, appStore.darkTheme, appStore.activeFrame.frameInfo.fileInfo.name)}
                 />
                 <Menu.Divider/>
                 <Menu.Item text="Preferences" icon={"cog"} label={`${modString}P`} disabled={true}/>

--- a/src/components/RenderConfig/RenderConfigComponent.tsx
+++ b/src/components/RenderConfig/RenderConfigComponent.tsx
@@ -194,11 +194,14 @@ export class RenderConfigComponent extends React.Component<WidgetProps> {
         if (frame && frame.unit) {
             unitString = `Value (${frame.unit})`;
         }
+        
+        const imageName = (appStore.activeFrame ? appStore.activeFrame.frameInfo.fileInfo.name : undefined);
 
         let linePlotProps: LinePlotComponentProps = {
             xLabel: unitString,
             yLabel: "Count",
             darkMode: appStore.darkTheme,
+            imageName: imageName,
             logY: this.widgetStore.logScaleY,
             usePointSymbols: this.widgetStore.plotType === PlotType.POINTS,
             interpolateLines: this.widgetStore.plotType === PlotType.LINES,

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -3,6 +3,7 @@ import {observer} from "mobx-react";
 import * as _ from "lodash";
 import {ESCAPE} from "@blueprintjs/core/lib/cjs/common/keys";
 import {ChartArea} from "chart.js";
+import {Scatter} from "react-chartjs-2";
 import {PlotContainerComponent} from "./PlotContainer/PlotContainerComponent";
 import {Arrow, Group, Layer, Line, Rect, Stage, Text} from "react-konva";
 import ReactResizeDetector from "react-resize-detector";
@@ -409,7 +410,9 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     
     exportImage = () => {
         console.log("+++ exportImage called!");
-        console.log(typeof this.plotRef);
+        const scatter = this.plotRef as Scatter;
+        console.log(typeof scatter);
+        // TODO: how to get canvas?!
     };
     
     exportData = () => {

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -408,6 +408,27 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         this.hideToolbar();
     };
     
+    private getTimestamp() {
+        const now = new Date();
+        return `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;
+    }
+    
+    private getCoordinate() {
+        if (this.props.xLabel.match(/X/)) {
+            return "-X";
+        }
+        
+        if (this.props.xLabel.match(/Y/)) {
+            return "-Y";
+        }
+        
+        if (this.props.xLabel.match(/Channel/)) {
+            return "-Z";
+        }
+        
+        return "";
+    }
+    
     exportImage = () => {
         const scatter = this.plotRef as Scatter;
         const canvas = scatter.chartInstance.canvas;
@@ -423,17 +444,23 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         
         const dataURL = composedCanvas.toDataURL().replace("image/png", "image/octet-stream");
         
-        const now = new Date();
-        const timestamp = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;
-        
         const a = document.createElement("a") as HTMLAnchorElement;
         a.href = dataURL;
-        a.download = `CARTA-exported-profile-${timestamp}.png`;
+        a.download = `CARTA-exported-profile${this.getCoordinate()}-${this.getTimestamp()}.png`;
         a.dispatchEvent(new MouseEvent("click"));
     };
     
     exportData = () => {
-        console.log("+++ exportData called!");
+        const header = "x\ty";
+        const rows = this.props.data.map(o => `${o.x}\t${o.y.toExponential(10)}`);
+        const tsvData = `data:text/tab-separated-values;charset=utf-8,${header}\n${rows.join("\n")}\n`;
+        
+        const dataURL = encodeURI(tsvData);
+        
+        const a = document.createElement("a") as HTMLAnchorElement;
+        a.href = dataURL;
+        a.download = `CARTA-exported-profile${this.getCoordinate()}-${this.getTimestamp()}.tsv`;
+        a.dispatchEvent(new MouseEvent("click"));
     };
 
     render() {
@@ -669,6 +696,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                 <ToolbarComponent
                     darkMode={this.props.darkMode}
                     visible={this.toolbarVisible}
+                    disabled={this.props.data === undefined}
                     exportImage={this.exportImage}
                     exportData={this.exportData}
                 />

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -411,7 +411,17 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     exportImage = () => {
         const scatter = this.plotRef as Scatter;
         const canvas = scatter.chartInstance.canvas;
-        const dataURL = canvas.toDataURL().replace("image/png", "image/octet-stream");
+        
+        const composedCanvas = document.createElement("canvas") as HTMLCanvasElement;
+        composedCanvas.width = canvas.width;
+        composedCanvas.height = canvas.height;
+            
+        const ctx = composedCanvas.getContext("2d");
+        ctx.fillStyle = this.props.darkMode ? Colors.DARK_GRAY3 : Colors.LIGHT_GRAY5;
+        ctx.fillRect(0, 0, composedCanvas.width, composedCanvas.height);
+        ctx.drawImage(canvas, 0, 0);
+        
+        const dataURL = composedCanvas.toDataURL().replace("image/png", "image/octet-stream");
         
         const now = new Date();
         const timestamp = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -414,20 +414,24 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         return `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;
     }
     
-    private getCoordinate() {
+    private getPlotName() {
         if (this.props.xLabel.match(/X/)) {
-            return "-X";
+            return "X profile";
         }
         
         if (this.props.xLabel.match(/Y/)) {
-            return "-Y";
+            return "Y profile";
         }
         
-        if (this.props.xLabel.match(/Channel/)) {
-            return "-Z";
+        if (this.props.xLabel === "Channel") {
+            return "Z profile";
         }
         
-        return "";
+        if (this.props.xLabel === "Value" && this.props.yLabel === "Count") {
+            return "histogram";
+        }
+        
+        return "unknown";
     }
     
     exportImage = () => {
@@ -447,21 +451,28 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         
         const a = document.createElement("a") as HTMLAnchorElement;
         a.href = dataURL;
-        a.download = `${this.props.imageName}-profile${this.getCoordinate()}-${this.getTimestamp()}.png`;
+        a.download = `${this.props.imageName}-${this.getPlotName().replace(" ", "-")}-${this.getTimestamp()}.png`;
         a.dispatchEvent(new MouseEvent("click"));
     };
     
     exportData = () => {
-        const comment = `# ${this.props.imageName} ${this.props.xLabel} profile`;
+        const comment = `# ${this.props.imageName} ${this.getPlotName()}`;
         const header = "x\ty";
-        const rows = this.props.data.map(o => `${o.x}\t${o.y.toExponential(10)}`);
+        
+        let rows;
+        if (this.getPlotName() === "histogram") {
+            rows = this.props.data.map(o => `${o.x.toExponential(10)}\t${o.y.toExponential(10)}`);
+        } else {
+            rows = this.props.data.map(o => `${o.x}\t${o.y.toExponential(10)}`);
+        }
+        
         const tsvData = `data:text/tab-separated-values;charset=utf-8,${comment}\n${header}\n${rows.join("\n")}\n`;
         
         const dataURL = encodeURI(tsvData).replace("#", "%23");
         
         const a = document.createElement("a") as HTMLAnchorElement;
         a.href = dataURL;
-        a.download = `${this.props.imageName}-profile${this.getCoordinate()}-${this.getTimestamp()}.tsv`;
+        a.download = `${this.props.imageName}-${this.getPlotName().replace(" ", "-")}-${this.getTimestamp()}.tsv`;
         a.dispatchEvent(new MouseEvent("click"));
     };
 

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -11,6 +11,7 @@ import "./LinePlotComponent.css";
 import {clamp} from "../../../util/math";
 import {Colors} from "@blueprintjs/core";
 import {action, computed, observable} from "mobx";
+import {ToolbarComponent} from "./Toolbar/ToolbarComponent";
 
 enum ZoomMode {
     NONE,
@@ -95,6 +96,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     @observable panStart = 0;
     @observable selectionBoxStart = {x: 0, y: 0};
     @observable selectionBoxEnd = {x: 0, y: 0};
+    @observable toolbarVisible = false;
 
     @computed get isSelecting() {
         return this.interactionMode === InteractionMode.SELECTING;
@@ -181,6 +183,14 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     @action resize = (w, h) => {
         this.width = w;
         this.height = h;
+    };
+    
+    @action showToolbar = () => {
+        this.toolbarVisible = true;
+    };
+    
+    @action hideToolbar = () => {
+        this.toolbarVisible = false;
     };
 
     dragBoundsFuncVertical = (pos: Point2D) => {
@@ -388,6 +398,23 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
             this.endInteractions();
         }
     };
+    
+    onMouseEnter = () => {
+        this.showToolbar();
+    };
+    
+    onMouseLeave = () => {
+        this.hideToolbar();
+    };
+    
+    exportImage = () => {
+        console.log("+++ exportImage called!");
+        console.log(typeof this.plotRef);
+    };
+    
+    exportData = () => {
+        console.log("+++ exportData called!");
+    };
 
     render() {
         const chartArea = this.chartArea;
@@ -586,7 +613,14 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         }
 
         return (
-            <div className={"line-plot-component"} style={{cursor: this.isPanning || isHovering ? "move" : "crosshair"}} onKeyDown={this.onKeyDown} tabIndex={0}>
+            <div 
+                className={"line-plot-component"}
+                style={{cursor: this.isPanning || isHovering ? "move" : "crosshair"}}
+                onKeyDown={this.onKeyDown}
+                onMouseEnter={this.onMouseEnter}
+                onMouseLeave={this.onMouseLeave}
+                tabIndex={0}
+            >
                 <ReactResizeDetector handleWidth handleHeight onResize={this.resize} refreshMode={"throttle"} refreshRate={33}/>
                 <PlotContainerComponent
                     {...this.props}
@@ -612,6 +646,12 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                         {borderRect}
                     </Layer>
                 </Stage>
+                <ToolbarComponent
+                    darkMode={this.props.darkMode}
+                    visible={this.toolbarVisible}
+                    exportImage={this.exportImage}
+                    exportData={this.exportData}
+                />
             </div>
 
         );

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -53,6 +53,7 @@ export class LinePlotComponentProps {
     logY?: boolean;
     lineColor?: string;
     darkMode?: boolean;
+    imageName?: string;
     usePointSymbols?: boolean;
     forceScientificNotationTicksX?: boolean;
     forceScientificNotationTicksY?: boolean;
@@ -446,20 +447,21 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
         
         const a = document.createElement("a") as HTMLAnchorElement;
         a.href = dataURL;
-        a.download = `CARTA-exported-profile${this.getCoordinate()}-${this.getTimestamp()}.png`;
+        a.download = `${this.props.imageName}-profile${this.getCoordinate()}-${this.getTimestamp()}.png`;
         a.dispatchEvent(new MouseEvent("click"));
     };
     
     exportData = () => {
+        const comment = `# ${this.props.imageName} ${this.props.xLabel} profile`;
         const header = "x\ty";
         const rows = this.props.data.map(o => `${o.x}\t${o.y.toExponential(10)}`);
-        const tsvData = `data:text/tab-separated-values;charset=utf-8,${header}\n${rows.join("\n")}\n`;
+        const tsvData = `data:text/tab-separated-values;charset=utf-8,${comment}\n${header}\n${rows.join("\n")}\n`;
         
-        const dataURL = encodeURI(tsvData);
+        const dataURL = encodeURI(tsvData).replace("#", "%23");
         
         const a = document.createElement("a") as HTMLAnchorElement;
         a.href = dataURL;
-        a.download = `CARTA-exported-profile${this.getCoordinate()}-${this.getTimestamp()}.tsv`;
+        a.download = `${this.props.imageName}-profile${this.getCoordinate()}-${this.getTimestamp()}.tsv`;
         a.dispatchEvent(new MouseEvent("click"));
     };
 

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -409,10 +409,17 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
     };
     
     exportImage = () => {
-        console.log("+++ exportImage called!");
         const scatter = this.plotRef as Scatter;
-        console.log(typeof scatter);
-        // TODO: how to get canvas?!
+        const canvas = scatter.chartInstance.canvas;
+        const dataURL = canvas.toDataURL().replace("image/png", "image/octet-stream");
+        
+        const now = new Date();
+        const timestamp = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;
+        
+        const a = document.createElement("a") as HTMLAnchorElement;
+        a.href = dataURL;
+        a.download = `CARTA-exported-profile-${timestamp}.png`;
+        a.dispatchEvent(new MouseEvent("click"));
     };
     
     exportData = () => {

--- a/src/components/Shared/LinePlot/LinePlotComponent.tsx
+++ b/src/components/Shared/LinePlot/LinePlotComponent.tsx
@@ -697,8 +697,7 @@ export class LinePlotComponent extends React.Component<LinePlotComponentProps> {
                 </Stage>
                 <ToolbarComponent
                     darkMode={this.props.darkMode}
-                    visible={this.toolbarVisible}
-                    disabled={this.props.data === undefined}
+                    visible={this.toolbarVisible && (this.props.data !== undefined)}
                     exportImage={this.exportImage}
                     exportData={this.exportData}
                 />

--- a/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.scss
+++ b/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.scss
@@ -1,0 +1,7 @@
+.profiler-toolbar {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    margin: 0 5px 0 0;
+    transition: opacity 400ms;
+}

--- a/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.tsx
+++ b/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.tsx
@@ -7,7 +7,6 @@ import {Button, ButtonGroup, Tooltip} from "@blueprintjs/core";
 export class ToolbarComponentProps {
     darkMode: boolean;
     visible: boolean;
-    disabled: boolean;
     exportImage: () => void;
     exportData: () => void;
 }
@@ -29,10 +28,10 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         return (
             <ButtonGroup className={className} style={styleProps}>
                 <Tooltip content="Export image">
-                    <Button icon="floppy-disk" disabled={this.props.disabled} onClick={this.props.exportImage}/>
+                    <Button icon="floppy-disk" onClick={this.props.exportImage}/>
                 </Tooltip>
                 <Tooltip content="Export data">
-                    <Button icon="th" disabled={this.props.disabled} onClick={this.props.exportData}/>
+                    <Button icon="th" onClick={this.props.exportData}/>
                 </Tooltip>
             </ButtonGroup>
         );

--- a/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.tsx
+++ b/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.tsx
@@ -7,6 +7,7 @@ import {Button, ButtonGroup, Tooltip} from "@blueprintjs/core";
 export class ToolbarComponentProps {
     darkMode: boolean;
     visible: boolean;
+    disabled: boolean;
     exportImage: () => void;
     exportData: () => void;
 }
@@ -28,10 +29,10 @@ export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
         return (
             <ButtonGroup className={className} style={styleProps}>
                 <Tooltip content="Export image">
-                    <Button icon="floppy-disk" onClick={this.props.exportImage}/>
+                    <Button icon="floppy-disk" disabled={this.props.disabled} onClick={this.props.exportImage}/>
                 </Tooltip>
                 <Tooltip content="Export data">
-                    <Button icon="th" onClick={this.props.exportData}/>
+                    <Button icon="th" disabled={this.props.disabled} onClick={this.props.exportData}/>
                 </Tooltip>
             </ButtonGroup>
         );

--- a/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.tsx
+++ b/src/components/Shared/LinePlot/Toolbar/ToolbarComponent.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import {CSSProperties} from "react";
+import {observer} from "mobx-react";
+import "./ToolbarComponent.css";
+import {Button, ButtonGroup, Tooltip} from "@blueprintjs/core";
+
+export class ToolbarComponentProps {
+    darkMode: boolean;
+    visible: boolean;
+    exportImage: () => void;
+    exportData: () => void;
+}
+
+@observer
+export class ToolbarComponent extends React.Component<ToolbarComponentProps> {
+
+    render() {
+        let styleProps: CSSProperties = {
+            opacity: this.props.visible ? 1 : 0
+        };
+
+        let className = "profiler-toolbar";
+
+        if (this.props.darkMode) {
+            className += " bp3-dark";
+        }
+
+        return (
+            <ButtonGroup className={className} style={styleProps}>
+                <Tooltip content="Export image">
+                    <Button icon="floppy-disk" onClick={this.props.exportImage}/>
+                </Tooltip>
+                <Tooltip content="Export data">
+                    <Button icon="th" onClick={this.props.exportData}/>
+                </Tooltip>
+            </ButtonGroup>
+        );
+    }
+}

--- a/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
+++ b/src/components/SpatialProfiler/SpatialProfilerComponent.tsx
@@ -388,11 +388,14 @@ export class SpatialProfilerComponent extends React.Component<WidgetProps> {
         }
 
         const isXProfile = this.widgetStore.coordinate.indexOf("x") >= 0;
+        
+        const imageName = (appStore.activeFrame ? appStore.activeFrame.frameInfo.fileInfo.name : undefined);
 
         let linePlotProps: LinePlotComponentProps = {
             xLabel: `${isXProfile ? "X" : "Y"} coordinate`,
             yLabel: "Value",
             darkMode: appStore.darkTheme,
+            imageName: imageName,
             usePointSymbols: this.widgetStore.plotType === PlotType.POINTS,
             interpolateLines: this.widgetStore.plotType === PlotType.LINES,
             forceScientificNotationTicksY: true,

--- a/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
+++ b/src/components/SpectralProfiler/SpectralProfilerComponent.tsx
@@ -197,11 +197,14 @@ export class SpectralProfilerComponent extends React.Component<WidgetProps> {
         if (!this.widgetStore) {
             return <NonIdealState icon={"error"} title={"Missing profile"} description={"Profile not found"}/>;
         }
+        
+        const imageName = (appStore.activeFrame ? appStore.activeFrame.frameInfo.fileInfo.name : undefined);
 
         let linePlotProps: LinePlotComponentProps = {
             xLabel: "Channel",
             yLabel: "Value",
             darkMode: appStore.darkTheme,
+            imageName: imageName,
             usePointSymbols: this.widgetStore.plotType === PlotType.POINTS,
             interpolateLines: this.widgetStore.plotType === PlotType.LINES,
             forceScientificNotationTicksY: true,


### PR DESCRIPTION
* Profile graphs can be exported as either PNG images or data in TSV format.
* All exported image filenames are now prefixed with the filename of the original image. The name is also included in a comment in the TSV file.